### PR TITLE
Krytocon fixes

### DIFF
--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -481,7 +481,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 					this.directDamage(pokemon.maxhp / 4, pokemon, pokemon);
 					activated = true;
 				}
-				target.addVolatile('curse');
+				target.addVolatile('curse', pokemon);
 			}
 		},
 	},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -920,7 +920,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			}
 		},
 		onModifyMove(move, source, target) {
-			if (target?.beingCalledBack || target?.switchFlag) move.accuracy = true;
+			if (target?.beingCalledBack || target?.switchFlag) {
+				move.accuracy = true;
+				move.onAfterMoveSecondarySelf = function (pokemon, target, move) {
+					if (!target || target.fainted || target.hp <= 0) {
+						this.boost({atk: 2}, pokemon, pokemon, move);
+					}
+				};
+			}
 		},
 		onTryHit(target, pokemon) {
 			target.side.removeSideCondition('attackofopportunity');
@@ -934,7 +941,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				for (const source of this.effectState.sources) {
 					if (!source.isAdjacent(pokemon) || !this.queue.cancelMove(source) || !source.hp) continue;
 					if (!alreadyAdded) {
-						this.add('-activate', pokemon, 'move: Attack of Opportunity');
+						this.add('-activate', pokemon, 'move: Pursuit');
 						alreadyAdded = true;
 					}
 					if (source.canMegaEvo) {
@@ -949,12 +956,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.actions.runMove('attackofopportunity', source, source.getLocOf(pokemon));
 				}
 			},
-		},
-		onAfterMoveSecondarySelf(pokemon, target, move) {
-			if (!target || target.fainted || target.hp <= 0 ||
-				target.beingCalledBack || target.switchFlag) {
-				this.boost({atk: 2}, pokemon, pokemon, move);
-			}
 		},
 		secondary: null,
 		target: "normal",

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -381,7 +381,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				for (const source of this.effectState.sources) {
 					if (!source.isAdjacent(pokemon) || !this.queue.cancelMove(source) || !source.hp) continue;
 					if (!alreadyAdded) {
-						this.add('-activate', pokemon, 'move: Trivial Pursuit');
+						this.add('-activate', pokemon, 'move: Pursuit');
 						alreadyAdded = true;
 					}
 					// Run through each action in queue to check if the Pursuit user is supposed to Mega Evolve this turn.

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -922,9 +922,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onModifyMove(move, source, target) {
 			if (target?.beingCalledBack || target?.switchFlag) {
 				move.accuracy = true;
-				move.onAfterMoveSecondarySelf = function (pokemon, target, move) {
-					if (!target || target.fainted || target.hp <= 0) {
-						this.boost({atk: 2}, pokemon, pokemon, move);
+				move.onAfterMoveSecondarySelf = function (s, t, m) {
+					if (!t || t.fainted || t.hp <= 0) {
+						this.boost({atk: 2}, s, s, m);
 					}
 				};
 			}

--- a/data/mods/ssb/random-teams.ts
+++ b/data/mods/ssb/random-teams.ts
@@ -191,7 +191,7 @@ export const ssbSets: SSBSets = {
 		species: 'Mawile', ability: 'Curse of Dexit', item: 'Mawilite', gender: 'M',
 		moves: ['Sucker Punch', 'Fire Lash', 'Play Rough'],
 		signatureMove: 'Attack of Opportunity',
-		evs: {hp: 252, atk: 252, spd: 4}, nature: 'Adamant', teraType: 'Any', shiny: 1024,
+		evs: {hp: 252, atk: 252, spd: 4}, nature: 'Adamant', shiny: 1024,
 	},
 	Lalaya: {
 		species: 'Murkrow', ability: 'Workaholic', item: 'Loaded Dice', gender: 'F',


### PR DESCRIPTION
- Fixes the message curse shows (used to read like the opponent put a curse on itself)
- Fixes Attack of Opportunity giving a +2 boost for KOing an opponent that wasn't switching out or hitting an opponent that is switching out but didn't faint to the attack.
- Now properly shows Pursuit's ([TARGET] is being withdrawn...) message