### PR TITLE
Add nya

### DIFF
--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -120,6 +120,23 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		},
 	},
 
+	// Bidoof Princess
+	adorablegrace: {
+		shortDesc: "This Pokemon's secondary effects and certain items have their activation chance doubled.",
+		name: "Adorable Grace",
+		onModifyMovePriority: -2,
+		onModifyMove(move) {
+			if (move.secondaries) {
+				this.debug('doubling secondary chance');
+				for (const secondary of move.secondaries) {
+					if (secondary.chance) secondary.chance *= 2;
+				}
+			}
+			if (move.self?.chance) move.self.chance *= 2;
+		},
+		// Item chances modified in items.js
+	},
+
 	// Blitz
 	blitzofruin: {
 		shortDesc: "Active Pokemon without this Ability have their Speed multiplied by 0.75. Also Dazzling.",

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -120,23 +120,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		},
 	},
 
-	// Bidoof Princess
-	adorablegrace: {
-		shortDesc: "This Pokemon's secondary effects and certain items have their activation chance doubled.",
-		name: "Adorable Grace",
-		onModifyMovePriority: -2,
-		onModifyMove(move) {
-			if (move.secondaries) {
-				this.debug('doubling secondary chance');
-				for (const secondary of move.secondaries) {
-					if (secondary.chance) secondary.chance *= 2;
-				}
-			}
-			if (move.self?.chance) move.self.chance *= 2;
-		},
-		// Item chances modified in items.js
-	},
-
 	// Blitz
 	blitzofruin: {
 		shortDesc: "Active Pokemon without this Ability have their Speed multiplied by 0.75. Also Dazzling.",
@@ -742,6 +725,23 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				return priority + 1;
 			}
 		},
+	},
+
+	// nya
+	adorablegrace: {
+		shortDesc: "This Pokemon's secondary effects and certain items have their activation chance doubled.",
+		name: "Adorable Grace",
+		onModifyMovePriority: -2,
+		onModifyMove(move) {
+			if (move.secondaries) {
+				this.debug('doubling secondary chance');
+				for (const secondary of move.secondaries) {
+					if (secondary.chance) secondary.chance *= 2;
+				}
+			}
+			if (move.self?.chance) move.self.chance *= 2;
+		},
+		// Item chances modified in items.js
 	},
 
 	// phoopes

--- a/data/mods/gen9ssb/conditions.ts
+++ b/data/mods/gen9ssb/conditions.ts
@@ -97,6 +97,18 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add(`c:|${getName('Archas')}|What would Grandfather... think of me now...`);
 		},
 	},
+	bidoofprincess: {
+		noCopy: true,
+		onStart() {
+			this.add(`c:|${getName('Bidoof ❤ Princess')}|:3`);
+		},
+		onSwitchOut() {
+			this.add(`c:|${getName('Bidoof ❤ Princess')}|nya~`);
+		},
+		onFaint() {
+			this.add(`c:|${getName('Bidoof ❤ Princess')}|>~<`);
+		},
+	},
 	blitzuser: {
 		noCopy: true,
 		onStart(pokemon) {
@@ -933,7 +945,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 	attract: {
 		onStart(pokemon, source, effect) {
 			if (!(pokemon.gender === 'M' && source.gender === 'F') && !(pokemon.gender === 'F' && source.gender === 'M')) {
-				if (effect.name !== 'The Love Of Christ') {
+				if (!['The Love Of Christ', ':3'].includes(effect.name)) {
 					this.debug('incompatible gender');
 					return false;
 				}

--- a/data/mods/gen9ssb/conditions.ts
+++ b/data/mods/gen9ssb/conditions.ts
@@ -97,18 +97,6 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add(`c:|${getName('Archas')}|What would Grandfather... think of me now...`);
 		},
 	},
-	bidoofprincess: {
-		noCopy: true,
-		onStart() {
-			this.add(`c:|${getName('Bidoof ❤ Princess')}|:3`);
-		},
-		onSwitchOut() {
-			this.add(`c:|${getName('Bidoof ❤ Princess')}|nya~`);
-		},
-		onFaint() {
-			this.add(`c:|${getName('Bidoof ❤ Princess')}|>~<`);
-		},
-	},
 	blitzuser: {
 		noCopy: true,
 		onStart(pokemon) {
@@ -553,6 +541,18 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 		},
 		onFaint() {
 			this.add(`c:|${getName('neycwang')}|How long am I banned for?`);
+		},
+	},
+	nya: {
+		noCopy: true,
+		onStart() {
+			this.add(`c:|${getName('nya~ ❤')}|:3`);
+		},
+		onSwitchOut() {
+			this.add(`c:|${getName('nya~ ❤')}|nya~`);
+		},
+		onFaint() {
+			this.add(`c:|${getName('nya~ ❤')}|>~<`);
 		},
 	},
 	peary: {

--- a/data/mods/gen9ssb/items.ts
+++ b/data/mods/gen9ssb/items.ts
@@ -37,7 +37,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 		desc: "If held by a Klinklang with Gear Grind, it can use 1000 Gears.",
 	},
 
-	// modified for Bidoof Princess' ability
+	// modified for nya's ability
 	focusband: {
 		inherit: true,
 		onDamage(damage, target, source, effect) {

--- a/data/mods/gen9ssb/items.ts
+++ b/data/mods/gen9ssb/items.ts
@@ -36,4 +36,26 @@ export const Items: {[k: string]: ModdedItemData} = {
 		itemUser: ["Klinklang"],
 		desc: "If held by a Klinklang with Gear Grind, it can use 1000 Gears.",
 	},
+
+	// modified for Bidoof Princess' ability
+	focusband: {
+		inherit: true,
+		onDamage(damage, target, source, effect) {
+			const chance = target.hasAbility('adorablegrace') ? 2 : 1;
+			if (this.randomChance(chance, 10) && damage >= target.hp && effect && effect.effectType === 'Move') {
+				this.add("-activate", target, "item: Focus Band");
+				return target.hp - 1;
+			}
+		},
+	},
+	quickclaw: {
+		inherit: true,
+		onFractionalPriority(priority, pokemon) {
+			const chance = pokemon.hasAbility('adorablegrace') ? 2 : 1;
+			if (priority <= 0 && this.randomChance(chance, 5)) {
+				this.add('-activate', pokemon, 'item: Quick Claw');
+				return 0.1;
+			}
+		},
+	},
 };

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -178,35 +178,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		type: "Grass",
 	},
 
-	// Bidoof Princess
-	'3': {
-		accuracy: 100,
-		basePower: 40,
-		category: "Special",
-		shortDesc: "Moves first. 50% chance to backfire. 40% infatuates.",
-		name: ":3",
-		gen: 9,
-		pp: 5,
-		priority: 1,
-		flags: {protect: 1},
-		onTry(pokemon, target, move) {
-			if (move.sourceEffect !== '3' && this.randomChance(1, 2)) {
-				this.add('-message', "The move backfired!");
-				this.actions.useMove('3', target, pokemon);
-				return null;
-			}
-		},
-		onPrepareHit() {
-			this.attrLastMove('[anim] Attract');
-		},
-		secondary: {
-			volatileStatus: 'attract',
-			chance: 40,
-		},
-		target: "normal",
-		type: "Fairy",
-	},
-
 	// Blitz
 	geyserblast: {
 		accuracy: 95,
@@ -1309,6 +1280,35 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		target: "normal",
 		type: "Ghost",
+	},
+
+	// nya
+	'3': {
+		accuracy: 100,
+		basePower: 40,
+		category: "Special",
+		shortDesc: "Moves first. 50% chance to backfire. 40% infatuates.",
+		name: ":3",
+		gen: 9,
+		pp: 5,
+		priority: 1,
+		flags: {protect: 1},
+		onTry(pokemon, target, move) {
+			if (move.sourceEffect !== '3' && this.randomChance(1, 2)) {
+				this.add('-message', "The move backfired!");
+				this.actions.useMove('3', target, pokemon);
+				return null;
+			}
+		},
+		onPrepareHit() {
+			this.attrLastMove('[anim] Attract');
+		},
+		secondary: {
+			volatileStatus: 'attract',
+			chance: 40,
+		},
+		target: "normal",
+		type: "Fairy",
 	},
 
 	// Peary

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -178,6 +178,35 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		type: "Grass",
 	},
 
+	// Bidoof Princess
+	'3': {
+		accuracy: 100,
+		basePower: 40,
+		category: "Special",
+		shortDesc: "Moves first. 50% chance to backfire. 40% infatuates.",
+		name: ":3",
+		gen: 9,
+		pp: 5,
+		priority: 1,
+		flags: {protect: 1},
+		onTry(pokemon, target, move) {
+			if (move.sourceEffect !== '3' && this.randomChance(1, 2)) {
+				this.add('-message', "The move backfired!");
+				this.actions.useMove('3', target, pokemon);
+				return null;
+			}
+		},
+		onPrepareHit() {
+			this.attrLastMove('[anim] Attract');
+		},
+		secondary: {
+			volatileStatus: 'attract',
+			chance: 40,
+		},
+		target: "normal",
+		type: "Fairy",
+	},
+
 	// Blitz
 	geyserblast: {
 		accuracy: 95,

--- a/data/mods/gen9ssb/random-teams.ts
+++ b/data/mods/gen9ssb/random-teams.ts
@@ -66,12 +66,6 @@ export const ssbSets: SSBSets = {
 		signatureMove: 'Quiver Dance',
 		evs: {spa: 252, spd: 4, spe: 252}, nature: 'Timid',
 	},
-	'Bidoof ❤ Princess': {
-		species: 'Delcatty', ability: 'Adorable Grace', item: 'Focus Band', gender: 'F',
-		moves: ['Frost Breath', 'Tri Attack', 'Volt Switch'],
-		signatureMove: ':3',
-		evs: {hp: 252, spa: 4, spe: 252}, nature: 'Naive', teraType: 'Ice',
-	},
 	Blitz: {
 		species: 'Chi-Yu', ability: 'Blitz of Ruin', item: 'Life Orb', gender: 'N',
 		moves: ['Fiery Wrath', 'Lava Plume', 'Nasty Plot'],
@@ -252,6 +246,12 @@ export const ssbSets: SSBSets = {
 		moves: ['Destiny Bond', 'Will-O-Wisp', 'Parting Shot'],
 		signatureMove: 'Shadow Dance',
 		evs: {hp: 252, atk: 252, def: 4}, ivs: {spe: 0}, nature: 'Brave', shiny: true,
+	},
+	'nya~ ❤': {
+		species: 'Delcatty', ability: 'Adorable Grace', item: 'Focus Band', gender: 'F',
+		moves: ['Frost Breath', 'Tri Attack', 'Volt Switch'],
+		signatureMove: ':3',
+		evs: {hp: 252, spa: 4, spe: 252}, nature: 'Naive', teraType: 'Ice',
 	},
 	Peary: {
 		species: 'Klinklang', ability: 'Levitate', item: 'Pearyum Z', gender: '',

--- a/data/mods/gen9ssb/random-teams.ts
+++ b/data/mods/gen9ssb/random-teams.ts
@@ -66,6 +66,12 @@ export const ssbSets: SSBSets = {
 		signatureMove: 'Quiver Dance',
 		evs: {spa: 252, spd: 4, spe: 252}, nature: 'Timid',
 	},
+	'Bidoof ❤ Princess': {
+		species: 'Delcatty', ability: 'Adorable Grace', item: 'Focus Band', gender: 'F',
+		moves: ['Frost Breath', 'Tri Attack', 'Volt Switch'],
+		signatureMove: ':3',
+		evs: {hp: 252, spa: 4, spe: 252}, nature: 'Naive', teraType: 'Ice',
+	},
 	Blitz: {
 		species: 'Chi-Yu', ability: 'Blitz of Ruin', item: 'Life Orb', gender: 'N',
 		moves: ['Fiery Wrath', 'Lava Plume', 'Nasty Plot'],


### PR DESCRIPTION
https://www.smogon.com/forums/threads/delcatty.3715932/

Tested in command line. Having a move with ID `3` results in behavior undefined by SIM-PROTOCOL, but it should still work fine on the official client; `move 3` will still use the move in slot 3, while `move :3` uses the Colon Three move